### PR TITLE
add agent-sandbox microvm

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,9 @@ jobs:
       - run: nix build --accept-flake-config .#nixosConfigurations.mothership.config.system.build.toplevel $VERBOSE_FLAGS
 
   arm-linux:
-    # Validates the aarch64-linux agent-sandbox micro VM builds on PRs.
+    # Validates the aarch64-linux agent-sandbox micro VM system closure builds
+    # on PRs. The vfkit runner is aarch64-darwin and is exercised in the Cachix
+    # workflow post-merge (it needs the linux closure in cache first).
     runs-on: ubuntu-24.04-arm
     env:
       VERBOSE_FLAGS: ${{ inputs.verbose == true && '--verbose --print-build-logs' || '' }}
@@ -41,8 +43,6 @@ jobs:
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-
-      - run: nix build --accept-flake-config .#nixosConfigurations.agent-sandbox.config.microvm.declaredRunner $VERBOSE_FLAGS
 
       - run: nix build --accept-flake-config .#nixosConfigurations.agent-sandbox.config.system.build.toplevel $VERBOSE_FLAGS
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,24 @@ jobs:
 
       - run: nix build --accept-flake-config .#nixosConfigurations.mothership.config.system.build.toplevel $VERBOSE_FLAGS
 
+  arm-linux:
+    # Validates the aarch64-linux agent-sandbox micro VM builds on PRs.
+    runs-on: ubuntu-24.04-arm
+    env:
+      VERBOSE_FLAGS: ${{ inputs.verbose == true && '--verbose --print-build-logs' || '' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - run: nix build --accept-flake-config .#nixosConfigurations.agent-sandbox.config.microvm.declaredRunner $VERBOSE_FLAGS
+
+      - run: nix build --accept-flake-config .#nixosConfigurations.agent-sandbox.config.system.build.toplevel $VERBOSE_FLAGS
+
   intel-macos:
     # runs-on: macos-12 # drachenflieger is on this version but runner deprecated
     runs-on: macos-15-intel

--- a/.github/workflows/cachix.yaml
+++ b/.github/workflows/cachix.yaml
@@ -38,6 +38,32 @@ jobs:
 
       - run: nix build --accept-flake-config .#nixosConfigurations.mothership.config.system.build.toplevel $VERBOSE_FLAGS
 
+  arm-linux:
+    # Builds the aarch64-linux agent-sandbox micro VM closure and pushes it to
+    # cachix, so the macOS hosts can substitute it via `microvm-run` instead of
+    # running the local linux-builder.
+    runs-on: ubuntu-24.04-arm
+    env:
+      VERBOSE_FLAGS: ${{ inputs.verbose == true && '--verbose --print-build-logs' || '' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Setup Cachix
+        uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16
+        with:
+          name: anthonyenr1quez
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - run: nix build --accept-flake-config .#nixosConfigurations.agent-sandbox.config.microvm.declaredRunner $VERBOSE_FLAGS
+
+      - run: nix build --accept-flake-config .#nixosConfigurations.agent-sandbox.config.system.build.toplevel $VERBOSE_FLAGS
+
   intel-macos:
     # runs-on: macos-12 # drachenflieger is on this version but runner deprecated
     runs-on: macos-15-intel

--- a/.github/workflows/cachix.yaml
+++ b/.github/workflows/cachix.yaml
@@ -39,9 +39,10 @@ jobs:
       - run: nix build --accept-flake-config .#nixosConfigurations.mothership.config.system.build.toplevel $VERBOSE_FLAGS
 
   arm-linux:
-    # Builds the aarch64-linux agent-sandbox micro VM closure and pushes it to
-    # cachix, so the macOS hosts can substitute it via `microvm-run` instead of
-    # running the local linux-builder.
+    # Builds the aarch64-linux agent-sandbox micro VM system closure and pushes
+    # it to cachix, so the macOS hosts can substitute it via `microvm-run`
+    # instead of running the local linux-builder. The vfkit runner itself is
+    # aarch64-darwin and is built in the arm-macos job below.
     runs-on: ubuntu-24.04-arm
     env:
       VERBOSE_FLAGS: ${{ inputs.verbose == true && '--verbose --print-build-logs' || '' }}
@@ -59,8 +60,6 @@ jobs:
         with:
           name: anthonyenr1quez
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-
-      - run: nix build --accept-flake-config .#nixosConfigurations.agent-sandbox.config.microvm.declaredRunner $VERBOSE_FLAGS
 
       - run: nix build --accept-flake-config .#nixosConfigurations.agent-sandbox.config.system.build.toplevel $VERBOSE_FLAGS
 
@@ -87,6 +86,10 @@ jobs:
       - run: nix build --accept-flake-config .#darwinConfigurations.drachenflieger.config.system.build.toplevel $VERBOSE_FLAGS
 
   arm-macos:
+    # Depends on arm-linux so the aarch64-linux VM closure is in cachix first;
+    # the aarch64-darwin vfkit runner can then substitute it instead of needing
+    # a local linux-builder on the runner.
+    needs: arm-linux
     runs-on: macos-26
     env:
       VERBOSE_FLAGS: ${{ inputs.verbose == true && '--verbose --print-build-logs' || '' }}
@@ -108,3 +111,5 @@ jobs:
       - run: nix build --accept-flake-config .#darwinConfigurations.MacBook-Pro-2.config.system.build.toplevel $VERBOSE_FLAGS
 
       - run: nix build --accept-flake-config .#darwinConfigurations.damascus.config.system.build.toplevel $VERBOSE_FLAGS
+
+      - run: nix build --accept-flake-config .#nixosConfigurations.agent-sandbox.config.microvm.declaredRunner $VERBOSE_FLAGS

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /result
+
+# microvm runtime artifacts (disk images, sockets, etc.)
+/microvm-test/

--- a/flake.lock
+++ b/flake.lock
@@ -117,6 +117,25 @@
         "type": "github"
       }
     },
+    "microvm": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "spectrum": "spectrum"
+      },
+      "locked": {
+        "lastModified": 1780588968,
+        "narHash": "sha256-zQk+GqLO+T9taIl1UUt3swvaOksWJxL7PL8K0+Fc/Hs=",
+        "owner": "microvm-nix",
+        "repo": "microvm.nix",
+        "rev": "4d3fb17437944ea57eef2b9e6108ca777b1209ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "microvm-nix",
+        "repo": "microvm.nix",
+        "type": "github"
+      }
+    },
     "nix-vscode-extensions": {
       "inputs": {
         "nixpkgs": [
@@ -159,6 +178,22 @@
       }
     },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1781268102,
         "narHash": "sha256-Zn5KTggEmUB3lXn/ccERNcBdddE6IaOFber9dWViWDg=",
@@ -224,14 +259,31 @@
         "darwin": "darwin",
         "flake-utils": "flake-utils",
         "home-manager": "home-manager",
+        "microvm": "microvm",
         "nix-vscode-extensions": "nix-vscode-extensions",
         "nixos-wsl": "nixos-wsl",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "nur": "nur",
         "opencode-session-search": "opencode-session-search",
         "stable": "stable",
         "systems": "systems",
         "vscode-server": "vscode-server"
+      }
+    },
+    "spectrum": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778940603,
+        "narHash": "sha256-voSM8dZNlaOWN3kbYFky+FNY6fFQOEw0xF+ZMpZKkCQ=",
+        "ref": "refs/heads/main",
+        "rev": "367dd227f539267eae2b62770b4c17b88ac8c1f1",
+        "revCount": 1265,
+        "type": "git",
+        "url": "https://spectrum-os.org/git/spectrum"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://spectrum-os.org/git/spectrum"
       }
     },
     "stable": {

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,13 @@
       url = "github:catppuccin/nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    microvm = {
+      url = "github:microvm-nix/microvm.nix";
+      # NOTE: intentionally NOT following our nixpkgs. microvm.nix's vfkit
+      # runner references `stdenv.hostPlatform.linux-kernel`, which our
+      # nixpkgs-unstable removed. Using microvm's pinned nixpkgs (which still
+      # has it) for the guest VM avoids that incompatibility.
+    };
     nur = {
       url = "github:nix-community/NUR";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -70,8 +77,12 @@
     };
   };
 
-  outputs = inputs@{ self, nixpkgs, nix-vscode-extensions, flake-utils, home-manager, nur, darwin, catppuccin, nixos-wsl, vscode-server, opencode-session-search, ... }:
+  outputs = inputs@{ self, nixpkgs, nix-vscode-extensions, flake-utils, home-manager, nur, darwin, catppuccin, microvm, nixos-wsl, vscode-server, opencode-session-search, ... }:
     let
+      # nixpkgs used to build the agent-sandbox guest VM. We use microvm.nix's
+      # own pinned nixpkgs (see the `microvm` input note) so the vfkit runner
+      # stays compatible.
+      microvmNixpkgs = microvm.inputs.nixpkgs;
       # generate a base darwin configuration with the
       # specified hostname, overlays, and any extraModules applied
       mkDarwinConfig =
@@ -103,10 +114,14 @@
           ]
         , profile ? "personal"
         , extraModules ? [ ]
+          # Include the agent-sandbox micro VM tooling (linux-builder toggle +
+          # microvm-run). Only valid on aarch64-darwin hosts (vfkit).
+        , microvm ? false
         }:
         inputs.darwin.lib.darwinSystem {
           inherit system;
-          modules = baseModules ++ extraModules;
+          modules = baseModules ++ extraModules
+            ++ nixpkgs.lib.optional microvm ./modules/microvm/darwin.nix;
           specialArgs = { inherit self inputs nixpkgs host profile; };
         };
 
@@ -146,11 +161,24 @@
     {
       darwinConfigurations = {
         drachenflieger = mkDarwinConfig { host = "drachenflieger"; };
-        damascus = mkDarwinConfig { host = "damascus"; system = "aarch64-darwin"; };
-        MacBook-Pro-2 = mkDarwinConfig { host = "MacBook-Pro-2"; system = "aarch64-darwin"; profile = "work"; };
+        damascus = mkDarwinConfig { host = "damascus"; system = "aarch64-darwin"; microvm = true; };
+        MacBook-Pro-2 = mkDarwinConfig { host = "MacBook-Pro-2"; system = "aarch64-darwin"; profile = "work"; microvm = true; };
       };
 
       nixosConfigurations = {
+        # LLM/agent sandbox micro VM, built for aarch64-linux and run on
+        # Apple Silicon macOS via vfkit. Build/run through `microvm-run` on a
+        # configured darwin host.
+        agent-sandbox = microvmNixpkgs.lib.nixosSystem {
+          system = "aarch64-linux";
+          specialArgs = { inherit self inputs; };
+          modules = [
+            microvm.nixosModules.microvm
+            ./modules/microvm/vm.nix
+            { microvm.vmHostPackages = microvmNixpkgs.legacyPackages.aarch64-darwin; }
+          ];
+        };
+
         mothership = mkNixosConfig {
           host = "mothership";
           extraModules = [

--- a/flake.nix
+++ b/flake.nix
@@ -174,6 +174,7 @@
           specialArgs = { inherit self inputs; };
           modules = [
             microvm.nixosModules.microvm
+            home-manager.nixosModules.home-manager
             ./modules/microvm/vm.nix
             { microvm.vmHostPackages = microvmNixpkgs.legacyPackages.aarch64-darwin; }
           ];

--- a/hosts/darwin/damascus/default.nix
+++ b/hosts/darwin/damascus/default.nix
@@ -1,4 +1,9 @@
 { config, pkgs, lib, ... }: {
+  # Set to true temporarily to (re)build the agent-sandbox micro VM locally,
+  # then back to false to free the builder VM's resources. Normally the VM
+  # closure is built in CI and pulled from cachix, so this can stay false.
+  microvm.linuxBuilder.enable = false;
+
   hm = {
     firefox = {
       bookmarksToolbar = "never";

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -29,6 +29,7 @@
       kubectx
       # kubelogin
       # kubernetes-helm-wrapped
+      nixd
       # pgadmin4
       # slack
       unar

--- a/modules/microvm/darwin.nix
+++ b/modules/microvm/darwin.nix
@@ -55,6 +55,22 @@ in
         enable = true;
         package = stablePkgs.darwin.linux-builder;
         systems = [ "aarch64-linux" ];
+
+        # Beefed-up builder VM for faster aarch64-linux builds while iterating.
+        # Defaults are ~1 vCPU / 3 GiB. Sized to leave headroom on a 16 GiB
+        # M3 MacBook Air (8 cores): give the builder 6 cores / 6 GiB so macOS
+        # keeps ~10 GiB and avoids heavy swapping.
+        # (Only matters while linuxBuilder.enable = true.)
+        maxJobs = 4;
+        config = {
+          virtualisation = {
+            cores = 6;
+            darwin-builder = {
+              memorySize = 6144; # 6 GiB
+              diskSize = 61440; # 60 GiB
+            };
+          };
+        };
       };
     };
   };

--- a/modules/microvm/darwin.nix
+++ b/modules/microvm/darwin.nix
@@ -1,0 +1,61 @@
+# Darwin-side wiring for the agent-sandbox micro VM.
+#
+# Provides:
+#   * a `microvm-run` command on PATH that boots the VM via vfkit, rebinding
+#     Ctrl-] to the interrupt/suspend/quit signals so Ctrl-C works *inside*
+#     the VM without shutting it down.
+#   * an opt-in NixOS linux-builder (aarch64-linux) needed to *build* the VM
+#     closure. It is off by default; flip `microvm.linuxBuilder.enable = true`
+#     and rebuild when you need to (re)build the VM, then turn it back off.
+#
+# The VM is defined in flake.nix as `nixosConfigurations.agent-sandbox`. The
+# `microvm-run` wrapper builds the aarch64-linux VM closure LAZILY at runtime
+# (via `nix build`) rather than embedding it as a build-time dependency of the
+# darwin system. Embedding it would force every `darwin-rebuild` to build the
+# VM, which requires the Linux builder and creates a chicken-and-egg problem.
+{ config, lib, pkgs, self, inputs, ... }:
+let
+  cfg = config.microvm.linuxBuilder;
+
+  # nixpkgs-unstable's qemu 11.0.0 crashes the linux-builder VM on macOS
+  # (SIGABRT in hvf_arch_init_vcpu under Hypervisor.framework).
+  # See https://github.com/NixOS/nixpkgs/issues/528299. Use the stable
+  # (nixos-26.05) builder, which ships qemu 10.2.2 and works.
+  stablePkgs = inputs.stable.legacyPackages.${pkgs.stdenv.hostPlatform.system};
+
+  flakeRef = self.outPath;
+  runnerAttr = "nixosConfigurations.agent-sandbox.config.microvm.declaredRunner";
+
+  microvm-run = pkgs.writeShellScriptBin "microvm-run" ''
+    set -euo pipefail
+
+    echo "Building agent-sandbox micro VM (this needs the Linux builder)..." >&2
+    runner=$(${lib.getExe pkgs.nix} build --no-link --print-out-paths \
+      "${flakeRef}#${runnerAttr}")
+
+    cleanup() { stty "$(stty -g)"; }
+    trap cleanup EXIT
+    stty intr ^] susp ^] quit ^]
+    exec "$runner/bin/microvm-run"
+  '';
+in
+{
+  options.microvm.linuxBuilder.enable = lib.mkEnableOption ''
+    the aarch64-linux NixOS linux-builder used to build the agent-sandbox
+    micro VM. Enable temporarily while iterating on the VM config, then
+    disable to free the builder VM's resources (~1 vCPU / 3 GiB RAM)
+  '';
+
+  config = {
+    environment.systemPackages = [ microvm-run ];
+
+    nix = lib.mkIf cfg.enable {
+      distributedBuilds = true;
+      linux-builder = {
+        enable = true;
+        package = stablePkgs.darwin.linux-builder;
+        systems = [ "aarch64-linux" ];
+      };
+    };
+  };
+}

--- a/modules/microvm/vm.nix
+++ b/modules/microvm/vm.nix
@@ -1,0 +1,74 @@
+# NixOS configuration for the LLM/agent sandbox micro VM.
+#
+# Built for aarch64-linux and run on Apple Silicon macOS hosts via vfkit
+# (Apple Virtualization framework). See:
+# https://abhinavsarkar.net/notes/2026-microvm-nix/
+#
+# Networking note: vfkit only supports user-mode (NAT) networking. The VM can
+# reach the host/internet outbound, but the host cannot initiate connections
+# into the VM.
+{ ... }:
+{
+  networking.hostName = "agent-sandbox";
+  services.getty.autologinUser = "root";
+
+  microvm = {
+    hypervisor = "vfkit";
+    vcpu = 4;
+    mem = 8192; # 8 GiB
+
+    # Writable overlay backed by a disk image so VM-local Nix builds/downloads
+    # don't fill the tmpfs root (RAM).
+    writableStoreOverlay = "/nix/.rw-store";
+
+    volumes = [
+      {
+        image = "nix-store-overlay.img";
+        mountPoint = "/nix/.rw-store";
+        size = 40960; # 40 GiB
+      }
+    ];
+
+    shares = [
+      # Host's read-only Nix store, combined with the writable overlay above.
+      {
+        proto = "virtiofs";
+        tag = "ro-store";
+        source = "/nix/store";
+        mountPoint = "/nix/.ro-store";
+      }
+      # NOTE: additional host directory shares (e.g. a projects/sandbox dir)
+      # can be added here later, e.g.:
+      # {
+      #   proto = "virtiofs";
+      #   tag = "projects";
+      #   source = "/Users/<you>/projects";
+      #   mountPoint = "/projects";
+      # }
+    ];
+
+    interfaces = [
+      {
+        type = "user";
+        id = "usernet";
+        mac = "02:00:00:01:01:01";
+      }
+    ];
+  };
+
+  networking.interfaces.eth0.useDHCP = true;
+
+  systemd.tmpfiles.rules = [
+    "d /nix/.rw-store/nix-build 0755 root root -"
+  ];
+
+  # Big gotcha workaround: the VM's root FS is a tmpfs (RAM), and Nix's build
+  # sandbox is created on the root FS by default. Disable the sandbox and point
+  # the build dir at the disk-backed overlay so builds don't exhaust RAM.
+  nix.settings = {
+    sandbox = false;
+    build-dir = "/nix/.rw-store/nix-build";
+  };
+
+  system.stateVersion = "26.05";
+}

--- a/modules/microvm/vm.nix
+++ b/modules/microvm/vm.nix
@@ -7,8 +7,10 @@
 # Networking note: vfkit only supports user-mode (NAT) networking. The VM can
 # reach the host/internet outbound, but the host cannot initiate connections
 # into the VM.
-{ ... }:
+{ inputs, lib, pkgs, ... }:
 {
+  imports = [ ../common.nix ];
+
   networking.hostName = "agent-sandbox";
   services.getty.autologinUser = "root";
 
@@ -68,7 +70,41 @@
   nix.settings = {
     sandbox = false;
     build-dir = "/nix/.rw-store/nix-build";
+    experimental-features = [ "nix-command" "flakes" ];
   };
+
+  # System-level build toolchain (used by Go/cgo and general dev work).
+  environment.systemPackages = with pkgs; [
+    gnumake
+    gcc
+  ];
+
+  # Treat the VM like another machine: reuse the shared system config
+  # (modules/common.nix), which bootstraps home-manager and pulls in the full
+  # modules/home-manager tooling barrel. The primary user here is root (the
+  # autologin user), so the tooling applies to root.
+  user = {
+    name = "root";
+    # common.nix derives this as /home/<name>; root's home is /root.
+    home = lib.mkForce "/root";
+  };
+
+  # The opencode home-manager module references pkgs.opencode-session-search
+  # (an overlay our host configs add). Provide it here too so the module works.
+  nixpkgs.overlays = [
+    (final: prev: {
+      opencode-session-search =
+        inputs.opencode-session-search.packages.${prev.stdenv.hostPlatform.system}.default;
+    })
+  ];
+
+  # GUI/desktop home-manager modules are opt-in (default off); enable just the
+  # opencode agent so an agent can run fully inside the sandbox.
+  hm.opencode.enable = true;
+
+  # Exit the sandbox by running `poweroff` at the prompt. (The microvm-run
+  # Ctrl-] trick relies on tty signal chars, which don't fire under fish's line
+  # editor, so `poweroff` is the reliable way out.)
 
   system.stateVersion = "26.05";
 }


### PR DESCRIPTION
NixOS micro VM (vfkit) for LLM/agent sandboxing on Apple Silicon.

- modules/microvm/{vm,darwin}.nix: VM config + linux-builder toggle and lazy microvm-run wrapper
- flake: microvm input (own nixpkgs to avoid qemu/linux-kernel issues) and nixosConfigurations.agent-sandbox; wired into both aarch64-darwin hosts
- linux-builder pinned to stable qemu 10.2.2 (nixpkgs#528299 HVF crash)
- CI: build + push agent-sandbox closure to cachix on arm-linux runner